### PR TITLE
Added ability to set authInfo on Request.

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -17,8 +17,9 @@ export function AuthGuard(
           httpContext.getResponse()
         ];
         const passportFn = createPassportContext(request, response);
-        const user = await passportFn(type, options);
-        request[options.property || defaultOptions.property] = user;
+        const userAndInfo = await passportFn(type, options);
+        request[options.property || defaultOptions.property] = (userAndInfo as any).user;
+        request[options.infoProperty || defaultOptions.infoProperty] = (userAndInfo as any).info;
         return true;
       }
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -3,16 +3,18 @@ import { UnauthorizedException } from '@nestjs/common';
 export interface AuthGuardOptions {
   session?: boolean;
   property?: string;
+  infoProperty?: string;
   callback?: (err, user, info?) => any;
 }
 
 export const defaultOptions = {
   session: false,
   property: 'user',
+  infoProperty: 'authInfo',
   callback: (err, user, info) => {
     if (err || !user) {
       throw err || new UnauthorizedException();
     }
-    return user;
+    return {user, info};
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs/passport",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "publish:npm": "npm publish --access public"
   },
   "peerDependencies": {
-    "@nestjs/common": "^5.0.0",
+    "@nestjs/common": "^5.1.0",
     "passport": "^0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
this will fix https://github.com/nestjs/passport/issues/10  issue.

## What is the new behavior?
new user can make use of optional `authInfo`
```ts
  async findAll(@Req() req): Promise<Project[]> {
    console.log(req.user)
    console.log(req.authInfo)
    return this.projectService.findAll();
  }
```
## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information