### PR TITLE
feature: integrates context into the handleRequest method of AuthGuard

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -16,7 +16,7 @@ export type IAuthGuard = CanActivate & {
   logIn<TRequest extends { logIn: Function } = any>(
     request: TRequest
   ): Promise<void>;
-  handleRequest<TUser = any>(err, user, info): TUser;
+  handleRequest<TUser = any>(err, user, info, context): TUser;
 };
 export const AuthGuard: (type?: string) => Type<IAuthGuard> = memoize(
   createAuthGuard
@@ -43,7 +43,7 @@ function createAuthGuard(type?: string): Type<CanActivate> {
       const user = await passportFn(
         type || this.options.defaultStrategy,
         options,
-        (err, info, user) => this.handleRequest(err, info, user)
+        (err, user, info) => this.handleRequest(err, user, info, context)
       );
       request[options.property || defaultOptions.property] = user;
       return true;
@@ -62,7 +62,7 @@ function createAuthGuard(type?: string): Type<CanActivate> {
       );
     }
 
-    handleRequest(err, user, info): TUser {
+    handleRequest(err, user, info, context): TUser {
       if (err || !user) {
         throw err || new UnauthorizedException();
       }


### PR DESCRIPTION
This feature integrates the context into the handleRequest method of the AuthGuard, so that not only the current user can be checked, but also the user's rights with regard to the context, e.g. with regard to decorators for access rights to resolvers. In addition, a bugfix is integrated which fixes an incorrect parameter sequence in the canActivate method.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Context is not available in the `handleRequest` method of `AuthGuard`
- The parameter sequence in the callback function and `handleRequest` call of the `canActivate` of `AuthGuard` is incorrect

Issue Number (for incorrect parameter sequence): #34


## What is the new behavior?

- An additional parameter makes the context in the `handleRequest` method of `AuthGuard` accessible.
- The parameter sequence in the callback function and the `handleRequest` call of the `canActivate` of `AuthGuard` is extended and correct

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```