### PR TITLE
bugfix: allow string array to be passed to auth guard

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -18,13 +18,13 @@ export type IAuthGuard = CanActivate & {
   ): Promise<void>;
   handleRequest<TUser = any>(err, user, info): TUser;
 };
-export const AuthGuard: (type?: string) => Type<IAuthGuard> = memoize(
-  createAuthGuard
-);
+export const AuthGuard: (
+  type?: string | string[]
+) => Type<IAuthGuard> = memoize(createAuthGuard);
 
 const NO_STRATEGY_ERROR = `In order to use "defaultStrategy", please, ensure to import PassportModule in each place where AuthGuard() is being used. Otherwise, passport won't work correctly.`;
 
-function createAuthGuard(type?: string): Type<CanActivate> {
+function createAuthGuard(type?: string | string[]): Type<CanActivate> {
   class MixinAuthGuard<TUser = any> implements CanActivate {
     constructor(@Optional() protected readonly options?: AuthModuleOptions) {
       this.options = this.options || {};

--- a/lib/interfaces/auth-module.options.ts
+++ b/lib/interfaces/auth-module.options.ts
@@ -1,7 +1,7 @@
 import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
 
 export interface IAuthModuleOptions<T = any> {
-  defaultStrategy?: string;
+  defaultStrategy?: string | string[];
   session?: boolean;
   property?: string;
   [key: string]: any;
@@ -22,7 +22,7 @@ export interface AuthModuleAsyncOptions
 }
 
 export class AuthModuleOptions implements IAuthModuleOptions {
-  defaultStrategy?: string;
+  defaultStrategy?: string | string[];
   session?: boolean;
   property?: string;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #67 


## What is the new behavior?

AuthGuard function and defaultStrategy both allow a string array to be set. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This PR does not break any existing code, but would allow several strategies to be set. 

## Other information