### PR TITLE
Add ability to pass in customParameters

### DIFF
--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -8,16 +8,24 @@ export function PassportStrategy<T extends Type<any> = any>(
   new (...args): T;
 } {
   abstract class MixinStrategy extends Strategy {
-    private readonly customParameters: {[key: string]: string};
+    private readonly customParameters: { [key: string]: string };
     abstract validate(...args: any[]): any;
 
     authenticate(...args: any[]): void {
       const [req, params, ...rest] = args;
-      if(this.customParameters && typeof params === 'object' && !Array.isArray(params)) {
-        return void super.authenticate(req, Object.assign(params, this.customParameters), ...rest)
+      if (
+        this.customParameters &&
+        typeof params === 'object' &&
+        !Array.isArray(params)
+      ) {
+        super.authenticate(
+          req,
+          Object.assign(params, this.customParameters),
+          ...rest
+        );
+      } else {
+        super.authenticate(...args);
       }
-
-      super.autenticate(...args);
     }
 
     constructor(...args: any[]) {
@@ -37,8 +45,8 @@ export function PassportStrategy<T extends Type<any> = any>(
 
       super(...args, (...params: any[]) => callback(...params));
 
-      const [ config ] = args || [] as any;
-      if(config && config.customParameters) {
+      const [config] = args || ([] as any);
+      if (config && config.customParameters) {
         this.customParameters = config.customParameters;
       }
 

--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -8,7 +8,18 @@ export function PassportStrategy<T extends Type<any> = any>(
   new (...args): T;
 } {
   abstract class MixinStrategy extends Strategy {
+    private readonly customParameters: {[key: string]: string};
     abstract validate(...args: any[]): any;
+
+    authenticate(...args: any[]): void {
+      const [req, params, ...rest] = args;
+      if(this.customParameters && typeof params === 'object' && !Array.isArray(params)) {
+        return void super.authenticate(req, Object.assign(params, this.customParameters), ...rest)
+      }
+
+      super.autenticate(...args);
+    }
+
     constructor(...args: any[]) {
       const callback = async (...params: any[]) => {
         const done = params[params.length - 1];
@@ -25,6 +36,12 @@ export function PassportStrategy<T extends Type<any> = any>(
       };
 
       super(...args, (...params: any[]) => callback(...params));
+
+      const [ config ] = args || [] as any;
+      if(config && config.customParameters) {
+        this.customParameters = config.customParameters;
+      }
+
       if (name) {
         passport.use(name, this as any);
       } else {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Custom parameters are not considered, which leads to issues where you're unable to specify provider specific fields mentioned in #57 

Issue Number: #57 


## What is the new behavior?

This takes the variable customParameters and automatically handles appending them to the authenticate call.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X ] No
```

This _shouldn't_ break anything as it only operates if the specific customParameters variable is set, and I believe most oauth strategies don't use this. 

*Looking for guidance if the variable name makes sense for the nest context*. I didn't use customParams because I felt like that had a higher likelihood of being used by some strategy.