### PR TITLE
Allow to override the passport instance used

### DIFF
--- a/lib/passport/passport.serializer.ts
+++ b/lib/passport/passport.serializer.ts
@@ -3,10 +3,16 @@ import * as passport from 'passport';
 export abstract class PassportSerializer {
   abstract serializeUser(user: any, done: Function);
   abstract deserializeUser(payload: any, done: Function);
+  getPassportInstance() {
+    return passport;
+  }
 
   constructor() {
-    passport.serializeUser((user, done) => this.serializeUser(user, done));
-    passport.deserializeUser((payload, done) =>
+    const passportInstance = this.getPassportInstance();
+    passportInstance.serializeUser((user, done) =>
+      this.serializeUser(user, done)
+    );
+    passportInstance.deserializeUser((payload, done) =>
       this.deserializeUser(payload, done)
     );
   }

--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -9,6 +9,10 @@ export function PassportStrategy<T extends Type<any> = any>(
 } {
   abstract class MixinStrategy extends Strategy {
     abstract validate(...args: any[]): any;
+    getPassportInstance() {
+      return passport;
+    }
+
     constructor(...args: any[]) {
       const callback = async (...params: any[]) => {
         const done = params[params.length - 1];
@@ -25,10 +29,11 @@ export function PassportStrategy<T extends Type<any> = any>(
       };
 
       super(...args, (...params: any[]) => callback(...params));
+      const passportInstance = this.getPassportInstance();
       if (name) {
-        passport.use(name, this as any);
+        passportInstance.use(name, this as any);
       } else {
-        passport.use(this as any);
+        passportInstance.use(this as any);
       }
     }
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: https://github.com/nestjs/passport/issues/26


## What is the new behavior?

By default, the old behavior applies (global passport singleton is used).

When the user instanciate the strategy and the serializer, they can override the `getPassportInstance` method to return a passport instance created somewhere (via `new passport.Passport()`).

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```


## Other information

I am not greatly convinced by this approach. This `getPassportInstance` pattern isn't very pretty, and the user of the library is responsible for giving the same instance to the strategy and the serializer.

Better ideas are more than welcome! I need this functionality for [NestJS Admin](https://github.com/williamdclt/nestjs-admin), as I don't want to pollute the user's passport instance :)