### PR TITLE
chore(build) Explicitly added rimraf as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Kamil Mysliwiec",
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "build": "rimraf dist && tsc -p tsconfig.json",
     "precommit": "lint-staged",
     "prepublish:npm": "npm run build",
     "publish:npm": "npm publish --access public"
@@ -23,6 +23,7 @@
     "passport": "0.4.0",
     "prettier": "1.19.1",
     "reflect-metadata": "0.1.13",
+    "rimraf": "^3.0.0",
     "rxjs": "6.5.3",
     "typescript": "3.7.2"
   },


### PR DESCRIPTION
 Explicitly added rimraf as devDependency (it already was implicitly), and made it be used in the build, so that it can be corss platform.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Doing ```npm run build``` from Windows fails, because there's no "rm" command on it.

Issue Number: N/A


## What is the new behavior?
Build succeeds as normal, thanks to the dist removal being delegated to rimraf.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information