### PR TITLE
feature(@nestjs/passport): add support for basic-auth with passport-http

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -63,6 +63,14 @@ function createAuthGuard(type?: string | string[]): Type<CanActivate> {
     }
 
     handleRequest(err, user, info, context): TUser {
+      if (!user && /^Basic/.test(info)) {
+        context.getResponse().setHeader('WWW-Authenticate', info);
+        context
+          .getResponse()
+          .status(401)
+          .send();
+        return;
+      }
       if (err || !user) {
         throw err || new UnauthorizedException();
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when using the BasicAuthStrategy from passport-http, the
parameter "info" is ignored when the callback is called. This leads to an
UnauthorizedException being thrown without the addition of the required
"WWW-Authenticate"-Header in the following response. This behavior causes
the browsers Authentication-Popup to not being shown.

Issue Number: N/A


## What is the new behavior?
With this commit, the parameter "info" is checked for the string "Basic"
which will be passed in by "passport-http" in order to be added to the
headers of the response. When the authentication was unsuccessful and the
info parameter is set the response will be send including the correct
header, thus enabling the popup window.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information