### PR TITLE
Fix passport-anonymous strategy hanging the request

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -86,5 +86,5 @@ const createPassportContext = (request, response) => (
       } catch (err) {
         reject(err);
       }
-    })(request, response, err => (err ? reject(err) : resolve))
+    })(request, response, err => (err ? reject(err) : resolve()))
   );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using passport-anonymous strategy it hangs the request, creating a promise that never resolves. passport-anonymous uses `this.pass` that simply calls next middleware with nothing, but there's a typo in auth.guard.ts that prevents resolve function to be called, thus hanging the request and creating stalled promise.

## What is the new behavior?
When using passport-anonymous strategy like this
```ts
@Controller()
@UseGuards(AuthGuard(['jwt', 'anonymous']))
class Controller {
  async get(@Req() request: Request) {
    const user = request.user;
    // ...
  }
}
```
the `user` variable can be undefined if `jwt` strategy fails. This can be utilized by controllers that can handle authenticated and also unauthenticated requests.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```