### PR TITLE
fix(core): Set callback function length

### DIFF
--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -25,7 +25,8 @@ export function PassportStrategy<T extends Type<any> = any>(
         }
       };
 
-      super(...args, (...params: any[]) => callback(...params));
+      super(...args, callback);
+      Object.defineProperty(callback, 'length', { value: this.validate.length + 1 });
       const passportInstance = this.getPassportInstance();
       if (name) {
         passportInstance.use(name, this as any);


### PR DESCRIPTION
Some strategies such as Azure AD use the length of the callback function to
determine the parameters but use of the spread results in a function length
of 0. See https://github.com/AzureAD/passport-azure-ad#5113-verify-callback.
This change sets the length of the callback function from the validate
method plus the done function.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The callback function provided to the passport strategy does not reflect the argument list of the validate method. See [Azure AD](https://github.com/AzureAD/passport-azure-ad/blob/dev/lib/oidcstrategy.js#L101-L125) official plugin for example of the issue I am currently facing.

## What is the new behavior?
The length property of the callback function is set to match that of the validate method plus the done callback.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information