### PR TITLE
refactor(passport): Strongly type constructor parameters

### DIFF
--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -5,12 +5,12 @@ export function PassportStrategy<T extends Type<any> = any>(
   Strategy: T,
   name?: string | undefined
 ): {
-  new (...args): InstanceType<T>;
+  new (...args: ConstructorParameters<T>): InstanceType<T>;
 } {
   abstract class MixinStrategy extends Strategy {
     abstract validate(...args: any[]): any;
 
-    constructor(...args: any[]) {
+    constructor(...args: ConstructorParameters<T>) {
       const callback = async (...params: any[]) => {
         const done = params[params.length - 1];
         try {


### PR DESCRIPTION
super() call must pass the same arguments as expected by the wrapped strategy instance, this change reflects this requirement.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Stronger typing for the passport `PassportStrategy` wrapper. It now correctly requires the `super()` call to pass the wrapped `Strategy` class's constructor parameters.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
NOTE: This is technically a breaking change. Explanation below.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

You may pass any argument to a wrapped Passport `Strategy`'s `super()`, even when those arguments are not what the underlying strategy expects.

Issue Number: N/A

## What is the new behavior?

Correct argument types are now enforced in compile time.
## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This is technically a breaking change, as the parent's constructor no longer accepts `any[]` arguments. However, deviations from the parent's constructor would have likely caused errors in runtime. It is unlikely that existing codebases need migration strategies, however, a simple cast to `any` would restore the original behavior.

## Other information