### PR TITLE
feat(@nestjs/passport): support graphql context in auth guard

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -5,8 +5,10 @@ import {
   Logger,
   mixin,
   Optional,
-  UnauthorizedException
+  UnauthorizedException,
+  ContextType
 } from '@nestjs/common';
+import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import * as passport from 'passport';
 import { Type } from './interfaces';
 import {
@@ -60,6 +62,14 @@ function createAuthGuard(type?: string | string[]): Type<CanActivate> {
     }
 
     getRequest<T = any>(context: ExecutionContext): T {
+      if (context.getType<ContextType | 'graphql'>() === 'graphql') {
+        const { GqlExecutionContext } = loadPackage(
+          '@nestjs/graphql',
+          'AuthGuard'
+        );
+        return GqlExecutionContext.create(context).getContext().req;
+      }
+
       return context.switchToHttp().getRequest();
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When adding AuthGuard to graphql resolver class/method you have to add custom logic for resolving the request object as described in Nest.js documentation https://docs.nestjs.com/techniques/authentication#graphql.
For example, to create a guard that would support both HTTP and GraphQL contexts you have to write something like this (the code is taken from one of my projects where both REST and GraphQL APIs should be supported):
```ts
import { AuthGuard } from '@nestjs/passport';
import { ExecutionContext, Injectable, ContextType } from '@nestjs/common';
import { GqlExecutionContext } from '@nestjs/graphql';
import { IncomingMessage } from 'http';

@Injectable()
export class JwtAuthGuard extends AuthGuard('jwt') {
  getRequest(context: ExecutionContext): any {
    if (context.getType<ContextType | 'graphql'>() === 'graphql') {
      const gqlExecCtx = GqlExecutionContext.create(context);
      const request: IncomingMessage = gqlExecCtx.getContext().req;
      return request;
    }
    return context.switchToHttp().getRequest();
  }
}
```
which works just perfect. But it is a boilerplate.

## What is the new behavior?
Now, with the built-in check for graphql context type and request object resolving logic, users will not have to write boilerplate code in each guard.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information