### PR TITLE
fix(): Preserve length property for verify callback

### DIFF
--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -24,8 +24,15 @@ export function PassportStrategy<T extends Type<any> = any>(
           done(err, null);
         }
       };
-
-      super(...args, (...params: any[]) => callback(...params));
+      const arity = new.target.prototype.validate.length;
+      const proxy = new Proxy(callback, {
+        get: function (target, name, receiver) {
+          return name === 'length'
+            ? arity
+            : Reflect.get(target, name, receiver);
+        }
+      });
+      super(...args, proxy);
       const passportInstance = this.getPassportInstance();
       if (name) {
         passportInstance.use(name, this as any);


### PR DESCRIPTION
Some passport strategies expect the value of a `length` property of verify callback to be equal to the number of arguments the callback receives, so we should preserve it.

Closes #434

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #434 


## What is the new behavior?
Callback that is passed to strategy constructor is wrapped into `Proxy` object, that returns `validate.length` instead of `callback.length`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
There was a lambda function in `super` call that seemed unnecessary to me, as it gets `...params` and calls callback with `...params`, so I've deleted it. Please correct me if I'm wrong and it was needed for some reason.