### PR TITLE
fix(): Preserve callback.length for strategy constructor

### DIFF
--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -25,7 +25,7 @@ export function PassportStrategy<T extends Type<any> = any>(
         }
       };
 
-      const validate = new.target.prototype.validate;
+      const validate = new.target?.prototype?.validate;
       if (validate) {
         Object.defineProperty(callback, 'length', {
           value: validate.length + 1

--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -25,12 +25,13 @@ export function PassportStrategy<T extends Type<any> = any>(
         }
       };
 
-      super(...args, callback);
-      if (this.validate) {
+      const validate = new.target.prototype.validate;
+      if (validate) {
         Object.defineProperty(callback, 'length', {
-          value: this.validate.length + 1
+          value: validate.length + 1
         });
       }
+      super(...args, callback);
 
       const passportInstance = this.getPassportInstance();
       if (name) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
`length` property is initialized after the strategy was constructed. See #435 for details.

## What is the new behavior?
The `length` property is initialized before the strategy was constructed, so the strategy constructor can use it somehow.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Implementation details
The `new.target` pseudo-property is supported since Typescript 2.2 and NodeJS 6.0.0. Being used in the constructor, it refers to the constructor that was directly invoked by `new`, so it can't be `undefined`.