### PR TITLE
make handleRequest promisable

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -20,7 +20,7 @@ export type IAuthGuard = CanActivate & {
   logIn<TRequest extends { logIn: Function } = any>(
     request: TRequest
   ): Promise<void>;
-  handleRequest<TUser = any>(err, user, info, context, status?): TUser;
+  handleRequest<TUser = any>(err, user, info, context, status?): TUser | Promise<TUser>;
   getAuthenticateOptions(context): IAuthModuleOptions | undefined;
 };
 export const AuthGuard: (


### PR DESCRIPTION
In the case where we want to attach some properties to the `request` object which is returning from the database or somewhere else with async. In such situation, the `handleRequest` returns the Promise.

@example
```js
async handleRequest(err, user, info, context): Promise<any> {
        if (err || !user) {
            throw err || new UnauthorizedException();
        }
        const req = context.switchToHttp().getRequest();
        let token = req.headers?.authorization?.split(" ")[1];
        if(token) {
            let tkn = await this.tokenService.getTokenInfo(token);
            if(tkn) {
                req._meta = {
                    token_id: tkn.id,
                    token: tkn.token,
                    user_id: tkn.user_id,
                    client_id: tkn.client_id
                }
            }
        }

        return user;
    }
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Return Type added
```

## What is the current behavior?
`handleRequest` in `auth.guard.ts` is not asynchronous

Issue Number: N/A


## What is the new behavior?
`handleRequest` in `auth.guard.ts` will be asynchronous too.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information