### PR TITLE
feat(@nestjs/passport): add promise support in getAuthenticateOptions

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -42,7 +42,7 @@ function createAuthGuard(type?: string | string[]): Type<CanActivate> {
       const options = {
         ...defaultOptions,
         ...this.options,
-        ...this.getAuthenticateOptions(context)
+        ...await this.getAuthenticateOptions(context)
       };
       const [request, response] = [
         this.getRequest(context),
@@ -85,7 +85,7 @@ function createAuthGuard(type?: string | string[]): Type<CanActivate> {
 
     getAuthenticateOptions(
       context: ExecutionContext
-    ): IAuthModuleOptions | undefined {
+    ): Promise<IAuthModuleOptions> | IAuthModuleOptions | undefined {
       return undefined;
     }
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Current implementation does not allow to apply async authentication options to the `AuthGuard`. The only solution is to provide in the preceding guard logic for collecting those informations and in "Express way" bind to the request to extract in 2nd one. 

Issue Number: N/A


## What is the new behavior?
There's no need to create 2 guards where first will be collecting necessary things (for example from auth0) and another will be proper `AuthGuard('auth0')`
```typescript
@Injectable()
export class LocalAuthGuard extends AuthGuard('auth0') {
  async getAuthenticateOptions(context: ExecutionContext): Promise<IAuthModuleOptions> {

    // get identifier, workspace etc...
    const additionalAsyncAuth0Options = await getSpecificDetailsFromAuth0();

    return {
      ...predefinedStaticValues,
      ...additionalAsyncAuth0Options
    };
  }
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information