### PR TITLE
More descriptive error in createPassportContext

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -105,6 +105,7 @@ const createPassportContext =
           request.authInfo = info;
           return resolve(callback(err, user, info, status));
         } catch (err) {
+          err.response.message = `${err.response.message} (${info})`;
           reject(err);
         }
       })(request, response, (err) => (err ? reject(err) : resolve()))

--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -34,11 +34,13 @@ function createAuthGuard(type?: string | string[]): Type<CanActivate> {
     @Optional()
     @Inject(AuthModuleOptions)
     protected options: AuthModuleOptions = {};
+    
+    protected logger: Logger = new Logger('AuthGuard');
 
     constructor(@Optional() options?: AuthModuleOptions) {
       this.options = options ?? this.options;
       if (!type && !this.options.defaultStrategy) {
-        new Logger('AuthGuard').error(NO_STRATEGY_ERROR);
+        this.logger.error(NO_STRATEGY_ERROR);
       }
     }
 
@@ -82,6 +84,7 @@ function createAuthGuard(type?: string | string[]): Type<CanActivate> {
 
     handleRequest(err, user, info, context, status): TUser {
       if (err || !user) {
+        this.logger.error(info);
         throw err || new UnauthorizedException();
       }
       return user;
@@ -105,7 +108,6 @@ const createPassportContext =
           request.authInfo = info;
           return resolve(callback(err, user, info, status));
         } catch (err) {
-          new Logger('AuthGuard').error(`${err.response.message} (${info})`);
           reject(err);
         }
       })(request, response, (err) => (err ? reject(err) : resolve()))

--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -105,7 +105,7 @@ const createPassportContext =
           request.authInfo = info;
           return resolve(callback(err, user, info, status));
         } catch (err) {
-          err.response.message = `${err.response.message} (${info})`;
+          new Logger('AuthGuard').error(`${err.response.message} (${info})`);
           reject(err);
         }
       })(request, response, (err) => (err ? reject(err) : resolve()))

--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -28,19 +28,18 @@ export const AuthGuard: (type?: string | string[]) => Type<IAuthGuard> =
   memoize(createAuthGuard);
 
 const NO_STRATEGY_ERROR = `In order to use "defaultStrategy", please, ensure to import PassportModule in each place where AuthGuard() is being used. Otherwise, passport won't work correctly.`;
+const AUTH_LOGGER = new Logger('AuthGuard');
 
 function createAuthGuard(type?: string | string[]): Type<CanActivate> {
   class MixinAuthGuard<TUser = any> implements CanActivate {
     @Optional()
     @Inject(AuthModuleOptions)
     protected options: AuthModuleOptions = {};
-    
-    protected logger = new Logger('AuthGuard');
 
     constructor(@Optional() options?: AuthModuleOptions) {
       this.options = options ?? this.options;
       if (!type && !this.options.defaultStrategy) {
-        this.logger.error(NO_STRATEGY_ERROR);
+        AUTH_LOGGER.error(NO_STRATEGY_ERROR);
       }
     }
 
@@ -84,7 +83,7 @@ function createAuthGuard(type?: string | string[]): Type<CanActivate> {
 
     handleRequest(err, user, info, context, status): TUser {
       if (err || !user) {
-        this.logger.error(info);
+        AUTH_LOGGER.error(info);
         throw err || new UnauthorizedException();
       }
       return user;

--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -35,7 +35,7 @@ function createAuthGuard(type?: string | string[]): Type<CanActivate> {
     @Inject(AuthModuleOptions)
     protected options: AuthModuleOptions = {};
     
-    protected logger: Logger = new Logger('AuthGuard');
+    protected logger = new Logger('AuthGuard');
 
     constructor(@Optional() options?: AuthModuleOptions) {
       this.options = options ?? this.options;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When encountering an error from a Passport Strategy, we end up with a page with that message, without further information:
```
{
  "statusCode": 401,
  "message": "Unauthorized"
}
```

## What is the new behavior?

This small change introduce more information in the error message (taking it from the Passport Strategy error), making it easier to identify the issue and fix it
```
{
  "statusCode": 401,
  "message": "Unauthorized (RPError: JWT not active yet, now 1646898893, nbf 1646898895)"
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Don't hesitate if you see any improvement that could be made 😉 