### PR TITLE
feat: add type to `context` parameter on `IAuthGuard`

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -21,8 +21,8 @@ export type IAuthGuard = CanActivate & {
   logIn<TRequest extends { logIn: Function } = any>(
     request: TRequest
   ): Promise<void>;
-  handleRequest<TUser = any>(err, user, info, context, status?): TUser;
-  getAuthenticateOptions(context): IAuthModuleOptions | undefined;
+  handleRequest<TUser = any>(err, user, info, context: ExecutionContext, status?): TUser;
+  getAuthenticateOptions(context: ExecutionContext): IAuthModuleOptions | undefined;
 };
 export const AuthGuard: (type?: string | string[]) => Type<IAuthGuard> =
   memoize(createAuthGuard);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
as of now, the `context` parameter of `handleRequest` and `getAuthenticateOptions` methods is `any`

I'm pretty sure the type will always be `ExecutionContext` from `@nestjs/common` due to how those methods are invoked below:

https://github.com/nestjs/passport/blob/ec086e4cd203963a43468f9b544b384c2e142f06/lib/auth.guard.ts#L45-L49

https://github.com/nestjs/passport/blob/ec086e4cd203963a43468f9b544b384c2e142f06/lib/auth.guard.ts#L60

## What is the new behavior?

adds the type `ExecutionContext` to them, instead of `any`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

