### PR TITLE
createPassportContext should be resolved with user

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -107,5 +107,5 @@ const createPassportContext =
         } catch (err) {
           reject(err);
         }
-      })(request, response, (err) => (err ? reject(err) : resolve()))
+      })(request, response, (err) => (err ? reject(err) : resolve(request[options.property || defaultOptions.property])))
     );


### PR DESCRIPTION
When you waiting four passportFn on line 56, you waiting for user and then set it to request.
In current version of passportjs SessionStrategy put user to request itself;
And in your method you override it.
These little pr will fix it without breaking any backward compability.

(I will adopt pr to guildlines soon)