### PR TITLE
feat: Allow specifying callback arity

### DIFF
--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -3,7 +3,8 @@ import { Type } from '../interfaces';
 
 export function PassportStrategy<T extends Type<any> = any>(
   Strategy: T,
-  name?: string | undefined
+  name?: string | undefined,
+  callbackArity?: true | Number
 ): {
   new (...args): InstanceType<T>;
 } {
@@ -24,17 +25,17 @@ export function PassportStrategy<T extends Type<any> = any>(
           done(err, null);
         }
       };
-      /**
-       * Commented out due to the regression it introduced
-       * Read more here: https://github.com/nestjs/passport/issues/446
 
+      if (callbackArity !== undefined) {
         const validate = new.target?.prototype?.validate;
+        const arity =
+          callbackArity === true ? validate.length + 1 : callbackArity;
         if (validate) {
           Object.defineProperty(callback, 'length', {
-            value: validate.length + 1
+            value: arity
           });
         }
-      */
+      }
       super(...args, callback);
 
       const passportInstance = this.getPassportInstance();

--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -4,7 +4,7 @@ import { Type } from '../interfaces';
 export function PassportStrategy<T extends Type<any> = any>(
   Strategy: T,
   name?: string | undefined,
-  callbackArity?: true | Number
+  callbackArity?: true | number
 ): {
   new (...args): InstanceType<T>;
 } {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The Callback nest passes to passport always has an arity of 0. The user can not influence this behavior.

Issue Number: 446


## What is the new behavior?
When creating a new strategy, the user can ask nest to calculate the arity of the callback based on the arity of the validate function or specify an arity to use.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I am a little lost on where to put a test for this behavior as well as where to make changes for the documentation. If someone can point me in the right direction, I will gladly make the necessary changes.

I am aware that the issue is long closed and a workaround is suggested. However, I feel that needing that workaround is a shortcoming of nest. I also fell that the discussion on the issue does not consider all available options (e.g. allowing the user to decide).

I would suggest making the the calculation of the callback arity the default and allowing the user to deactivate it, if necessary. However, this would make it a breaking change, so for the time being, the old behavior is the default.
