### PR TITLE
fix(@nestjs/passport): pass options to request.logIn

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -87,7 +87,7 @@ function createAuthGuard(type?: string | string[]): Type<IAuthGuard> {
     ): Promise<void> {
       const user = request[this.options.property || defaultOptions.property];
       await new Promise<void>((resolve, reject) =>
-        request.logIn(user, (err) => (err ? reject(err) : resolve()))
+        request.logIn(user, this.options, (err) => (err ? reject(err) : resolve()))
       );
     }
 


### PR DESCRIPTION
Pass options object to request.login method so that you anyone can use keepSessionInfo property when login

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [1385](https://github.com/nestjs/passport/issues/1385)


## What is the new behavior?
Allowing options to be passed will help developers preserve session between requests

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
