### PR TITLE
fix inherited constructor params types

### DIFF
--- a/lib/interfaces/type.interface.ts
+++ b/lib/interfaces/type.interface.ts
@@ -1,3 +1,9 @@
 export interface Type<T = any> extends Function {
   new (...args: any[]): T;
 }
+
+export type WithoutCallback<T extends any[]> =
+  // T extends any makes this distributive
+  T extends any ?
+    T extends [...infer U, any] ? U : T
+    : never;

--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -1,12 +1,12 @@
 import * as passport from 'passport';
-import { Type } from '../interfaces';
+import { Type, WithoutCallback} from '../interfaces';
 
 export function PassportStrategy<T extends Type<any> = any>(
   Strategy: T,
   name?: string | undefined,
   callbackArity?: true | number
 ): {
-  new (...args): InstanceType<T>;
+  new (...args: WithoutCallback<ConstructorParameters<T>>): InstanceType<T>;
 } {
   abstract class MixinStrategy extends Strategy {
     abstract validate(...args: any[]): any;


### PR DESCRIPTION
## PR Checklist
- fixes https://github.com/nestjs/passport/issues/1072
- motivation, why this is needed: https://tsplay.dev/mb3o9W

## PR Type
What kind of change does this PR introduce?

- type safety improvement

## What is the current behavior?
- missing type safety


## What is the new behavior?
- stronger type safety

## Does this PR introduce a breaking change?
- [x] Yes

It requires developer to really implement `validate` method as mentioned [here](https://docs.nestjs.com/recipes/passport#:~:text=You%20pass%20the%20strategy%20options%20(item%201%20above)%20by%20calling%20the%20super()%20method%20in%20your%20subclass%2C%20optionally%20passing%20in%20an%20options%20object.%20You%20provide%20the%20verify%20callback%20(item%202%20above)%20by%20implementing%20a%20validate()%20method%20in%20your%20subclass.). previously, you could pass it to `super()` by providing `verify` argument.

That means, previously, this was valid code:

```ts
@Injectable()
export class EcmsApiKeyStrategy extends PassportStrategy(HeaderAPIKeyStrategy, "api-key") {
    constructor() {
        super(
            { header: 'Authorization', prefix: 'Api-Key ' },
            true,
            (apikey: string, done: (...args: unknown[]) => void) => {
                return done(null, apikey === "some-random-token");
            },
        );
    }
}
```

but after this PR, I have to write:

```ts
@Injectable()
export class EcmsApiKeyStrategy extends PassportStrategy(HeaderAPIKeyStrategy, "api-key") {
    constructor() {
        super(
            { header: 'Authorization', prefix: 'Api-Key ' },
            true,
        );
    }

  validate(request: Request, payload: any) => {
      // here I will implement the logic
  }
}
```
