### PR TITLE
feat(@nestjs/passport): segregate authenticate opts from module opts

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -58,8 +58,8 @@ function createAuthGuard(type?: string | string[]): Type<IAuthGuard> {
     async canActivate(context: ExecutionContext): Promise<boolean> {
       const options = this.options;
       const authenticateOptions = {
-        ...defaultOptions.autenticateOptions,
-        ...options.autenticateOptions,
+        ...defaultOptions.authenticateOptions,
+        ...options.authenticateOptions,
         ...(await this.getAuthenticateOptions(context))
       };
       const [request, response] = [

--- a/lib/interfaces/auth-module.options.ts
+++ b/lib/interfaces/auth-module.options.ts
@@ -5,7 +5,7 @@ export interface IAuthModuleOptions<T = any> {
   defaultStrategy?: string | string[];
   session?: boolean;
   property?: string;
-  autenticateOptions?: AuthenticateOptions;
+  authenticateOptions?: AuthenticateOptions;
   [key: string]: any;
 }
 
@@ -27,5 +27,5 @@ export class AuthModuleOptions implements IAuthModuleOptions {
   defaultStrategy?: string | string[];
   session?: boolean;
   property?: string;
-  autenticateOptions?: AuthenticateOptions;
+  authenticateOptions?: AuthenticateOptions;
 }

--- a/lib/interfaces/auth-module.options.ts
+++ b/lib/interfaces/auth-module.options.ts
@@ -1,9 +1,11 @@
 import { ModuleMetadata, Type } from '@nestjs/common';
+import { AuthenticateOptions } from 'passport';
 
 export interface IAuthModuleOptions<T = any> {
   defaultStrategy?: string | string[];
   session?: boolean;
   property?: string;
+  autenticateOptions?: AuthenticateOptions;
   [key: string]: any;
 }
 
@@ -25,4 +27,5 @@ export class AuthModuleOptions implements IAuthModuleOptions {
   defaultStrategy?: string | string[];
   session?: boolean;
   property?: string;
+  autenticateOptions?: AuthenticateOptions;
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,4 +1,6 @@
-export const defaultOptions = {
+import { IAuthModuleOptions } from "./interfaces";
+
+export const defaultOptions: IAuthModuleOptions = {
   session: false,
   property: 'user'
 };

--- a/test/common/app.controller.ts
+++ b/test/common/app.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '../../lib';
 
 import { AppService } from './app.service';
+import { CustomGuard } from './custom.strategy';
 
 @Controller()
 export class AppController {
@@ -24,5 +25,17 @@ export class AppController {
       username: body.username,
       id: req.user.id
     });
+  }
+
+  @UseGuards(AuthGuard('custom'))
+  @Get('custom-guard')
+  getCustom(@Req() req: any) {
+    return req.user.state;
+  }
+
+  @UseGuards(CustomGuard)
+  @Get('custom-guard-with-state')
+  getCustomWithState(@Req() req: any) {
+    return req.user.state;
   }
 }

--- a/test/common/app.e2e-spec.ts
+++ b/test/common/app.e2e-spec.ts
@@ -34,6 +34,7 @@ describe.each`
         .expectBody({ message: 'Hello secure world!' });
     });
   });
+
   describe('UnauthenticatedFlow', () => {
     it('should return a 401 for an invalid login', async () => {
       await spec()
@@ -46,6 +47,66 @@ describe.each`
         .get('/private')
         .withHeaders('Authorization', 'Bearer not-a-jwt')
         .expectStatus(401);
+    });
+  });
+
+  describe('Custom strategy', () => {
+    it('should be able to hit the custom route and get the user "state" attribute', async () => {
+      await spec()
+        .get('/custom-guard-with-state')
+        .expectBody('custom-state-from-guard');
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+
+describe('Passport Module with register() specific', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const modRef = await Test.createTestingModule({
+      imports: [WithRegisterModule]
+    }).compile();
+    app = modRef.createNestApplication();
+    await app.listen(0);
+    const url = (await app.getUrl()).replace('[::1]', 'localhost');
+    request.setBaseUrl(url);
+  });
+
+  describe('Custom strategy', () => {
+    it('should be able to hit the custom route and get the user "state" attribute', async () => {
+      await spec()
+        .get('/custom-guard')
+        .expectBody('custom-state-from-register');
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+
+describe('Passport Module without register() specific', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const modRef = await Test.createTestingModule({
+      imports: [WithoutRegisterModule]
+    }).compile();
+    app = modRef.createNestApplication();
+    await app.listen(0);
+    const url = (await app.getUrl()).replace('[::1]', 'localhost');
+    request.setBaseUrl(url);
+  });
+
+  describe('Custom strategy', () => {
+    it('should be able to hit the custom route and get the user "state" attribute as empty', async () => {
+      await spec()
+        .get('/custom-guard')
+        .expectBody('');
     });
   });
 

--- a/test/common/custom.strategy.ts
+++ b/test/common/custom.strategy.ts
@@ -1,0 +1,37 @@
+import { ExecutionContext } from "@nestjs/common";
+import { AuthenticateOptions, StrategyCreated } from "passport";
+import { AuthGuard, PassportStrategy } from "../../lib";
+
+export class CustomGuard extends AuthGuard('custom') {
+  getAuthenticateOptions(context: ExecutionContext) : AuthenticateOptions {
+      return { state: 'custom-state-from-guard' }
+  }
+}
+
+export class CustomStrategy extends PassportStrategy(
+  class { constructor(readonly callback: CustomStrategyVerifyFunction) { } },
+  'custom'
+) {
+  async authenticate(this: this & StrategyCreated<this>, req: Request, options: AuthenticateOptions) {
+    this.callback(options, (err, user, failure) => {
+      if (err) {
+        return this.error(err);
+      }
+      if (!user) {
+        return this.fail(failure);
+      }
+      this.success(user, failure);
+    });
+  }
+
+  validate(...[options]: Parameters<CustomStrategyVerifyFunction>) {
+    return { id: 1, username: 'test', state: options.state };
+  }
+}
+
+interface CustomStrategyVerifyFunction {
+  (
+    options: AuthenticateOptions,
+    done: (error: any, user?: Express.User | false, info?: any) => void,
+  ): void;
+}

--- a/test/with-register/app.module.ts
+++ b/test/with-register/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from '../common/app.controller';
 import { AppService } from '../common/app.service';
 import { JwtStrategy } from '../common/jwt.strategy';
 import { LocalStrategy } from '../common/local.strategy';
+import { CustomStrategy } from '../common/custom.strategy';
 
 @Module({
   controllers: [AppController],
@@ -12,8 +13,12 @@ import { LocalStrategy } from '../common/local.strategy';
     JwtModule.register({
       secret: 's3cr3t'
     }),
-    PassportModule.register({})
+    PassportModule.register({
+      autenticateOptions: {
+        state: 'custom-state-from-register'
+      }
+    })
   ],
-  providers: [AppService, LocalStrategy, JwtStrategy]
+  providers: [AppService, CustomStrategy, LocalStrategy, JwtStrategy]
 })
 export class AppModule {}

--- a/test/with-register/app.module.ts
+++ b/test/with-register/app.module.ts
@@ -14,7 +14,7 @@ import { CustomStrategy } from '../common/custom.strategy';
       secret: 's3cr3t'
     }),
     PassportModule.register({
-      autenticateOptions: {
+      authenticateOptions: {
         state: 'custom-state-from-register'
       }
     })

--- a/test/without-register/app.module.ts
+++ b/test/without-register/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from '../common/app.controller';
 import { AppService } from '../common/app.service';
 import { JwtStrategy } from '../common/jwt.strategy';
 import { LocalStrategy } from '../common/local.strategy';
+import { CustomStrategy } from '../common/custom.strategy';
 
 @Module({
   controllers: [AppController],
@@ -14,6 +15,6 @@ import { LocalStrategy } from '../common/local.strategy';
     }),
     PassportModule
   ],
-  providers: [AppService, LocalStrategy, JwtStrategy]
+  providers: [AppService, CustomStrategy, LocalStrategy, JwtStrategy]
 })
 export class AppModule {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #947 


- `AuthGuard`'s constructor receives, by injection, the `AuthModuleOptions` object, that's responsible to configure the module of this library;
- `AuthGuard.getAuthenticateOptions` returns an object that matches the interface `IAuthModuleOptions`;
- `AuthGuard.canActivate` obtain the options from `getAuthenticateOptions` and merges it with the injected options of the `AuthGuard` instance;
- `AuthGuard.canActivate` pass the merged options to `passport.authenticate`.

## What is the new behavior?

- `AuthGuard`'s constructor receives, by injection, the `AuthModuleOptions` object, that's responsible to configure the module of this library within `authenticateOptions` property to generate the options parameter to call `passport.authenticate` function.
- `AuthGuard.getAuthenticateOptions` returns an object that matches the `passport.AuthenticateOptions` interface;
- `AuthGuard.canActivate` obtain the options from `getAuthenticateOptions` and merges it with the `authenticateOptions` from the injected options of the `AuthGuard` instance;
- `AuthGuard.canActivate` pass the merged options to `passport.authenticate`.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If the user defines some authenticate option when registering the authentication module by the module options, it must be defined inside `authenticateOptions` property.

```ts
// before:
PassportModule.register({
  defaultStrategy: 'local',
  session: true,
  failureRedirect: '/access-denied',
  successRedirect: '/home'
})

// after:
PassportModule.register({
  defaultStrategy: 'local',
  session: true,
  authenticateOptions: {
    failureRedirect: '/access-denied',
    successRedirect: '/home'
  }
})
```

## Other information

No more information.