### PR TITLE
fix(passport): preserve pass-through strategy user

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -74,7 +74,10 @@ function createAuthGuard(type?: string | string[]): Type<IAuthGuard> {
         (err, user, info, status) =>
           this.handleRequest(err, user, info, context, status)
       );
-      request[options.property || defaultOptions.property] = user;
+      const property = options.property || defaultOptions.property;
+      if (user !== undefined || !options.preserveExistingUserOnPass) {
+        request[property] = user;
+      }
       return true;
     }
 

--- a/lib/interfaces/auth-module.options.ts
+++ b/lib/interfaces/auth-module.options.ts
@@ -7,6 +7,7 @@ export interface IAuthModuleOptions {
   defaultStrategy?: string | string[];
   session?: boolean;
   property?: string;
+  preserveExistingUserOnPass?: boolean;
   [key: string]: any;
 }
 
@@ -20,8 +21,10 @@ export interface AuthOptionsFactory {
 /**
  * @publicApi
  */
-export interface AuthModuleAsyncOptions
-  extends Pick<ModuleMetadata, 'imports'> {
+export interface AuthModuleAsyncOptions extends Pick<
+  ModuleMetadata,
+  'imports'
+> {
   useExisting?: Type<AuthOptionsFactory>;
   useClass?: Type<AuthOptionsFactory>;
   useFactory?: (
@@ -37,4 +40,5 @@ export class AuthModuleOptions implements IAuthModuleOptions {
   defaultStrategy?: string | string[];
   session?: boolean;
   property?: string;
+  preserveExistingUserOnPass?: boolean;
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,4 +1,5 @@
 export const defaultOptions = {
   session: false,
-  property: 'user'
+  property: 'user',
+  preserveExistingUserOnPass: false
 };

--- a/test/authguard-pass-strategy.e2e-spec.ts
+++ b/test/authguard-pass-strategy.e2e-spec.ts
@@ -1,0 +1,69 @@
+import {
+  Controller,
+  Get,
+  INestApplication,
+  Req,
+  UseGuards
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as passport from 'passport';
+import { Strategy } from 'passport-strategy';
+import { request, spec } from 'pactum';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { AuthGuard, PassportModule } from '../lib';
+
+const STRATEGY_NAME = 'pass-through';
+
+class PassThroughStrategy extends Strategy {
+  name = STRATEGY_NAME;
+
+  authenticate(req: any) {
+    req.user = { id: 'restored-from-strategy' };
+    this.pass();
+  }
+}
+
+@Controller()
+class DefaultPassThroughController {
+  @UseGuards(AuthGuard(STRATEGY_NAME))
+  @Get('pass-through')
+  getUser(@Req() req: any) {
+    return { user: req.user ?? null };
+  }
+}
+
+describe('AuthGuard with pass-through strategies', () => {
+  describe.each`
+    description        | options                                 | expectedUser
+    ${'by default'}    | ${{}}                                   | ${null}
+    ${'when opted in'} | ${{ preserveExistingUserOnPass: true }} | ${{ id: 'restored-from-strategy' }}
+  `('$description', ({ options, expectedUser }) => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      passport.use(new PassThroughStrategy());
+
+      const modRef = await Test.createTestingModule({
+        controllers: [DefaultPassThroughController],
+        imports: [PassportModule.register(options)]
+      }).compile();
+      app = modRef.createNestApplication();
+      await app.listen(0);
+      const url = (await app.getUrl()).replace('[::1]', 'localhost');
+      request.setBaseUrl(url);
+    });
+
+    it('should handle request user restored by a pass-through strategy', async () => {
+      await spec().get('/pass-through').expectStatus(200).expectBody({
+        user: expectedUser
+      });
+
+      expect.assertions(0);
+    });
+
+    afterAll(async () => {
+      passport.unuse(STRATEGY_NAME);
+      await app.close();
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`AuthGuard` always writes the value returned by Passport authenticate callback to `req.user`. Pass-through strategies such as Passport session-style strategies can restore `req.user` directly and then call `pass()`, which means the callback result is `undefined`. In that path, `AuthGuard` overwrites the restored user with `undefined`.

Issue Number: Fixes #1505


## What is the new behavior?
The current behavior remains the default. A new opt-in `preserveExistingUserOnPass` option lets `AuthGuard` preserve an existing request user when Passport does not return a user value. This allows pass-through/session-style strategies to restore authentication state on the request without changing the default behavior for existing applications.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
Validated with:

```bash
npm test -- test/authguard-pass-strategy.e2e-spec.ts
npm test
npm run build
npm run lint
npx prettier --check lib/auth.guard.ts lib/interfaces/auth-module.options.ts lib/options.ts test/authguard-pass-strategy.e2e-spec.ts
git diff --check
```

Local note: checks were run with Node 22 because the current Vite/Vitest and oxlint toolchain requires a newer Node runtime than Node 20.18.