### PR TITLE
fix(passport): strip module options from authenticate

### DIFF
--- a/lib/auth.guard.ts
+++ b/lib/auth.guard.ts
@@ -31,7 +31,7 @@ export type IAuthGuard = CanActivate & {
   ): TUser;
   getAuthenticateOptions(
     context: ExecutionContext
-  ): IAuthModuleOptions | undefined;
+  ): Promise<IAuthModuleOptions> | IAuthModuleOptions | undefined;
   getRequest(context: ExecutionContext): any;
 };
 
@@ -70,7 +70,7 @@ function createAuthGuard(type?: string | string[]): Type<IAuthGuard> {
       const passportFn = createPassportContext(request, response);
       const user = await passportFn(
         type || this.options.defaultStrategy!,
-        options,
+        omitAuthModuleOptions(options),
         (err, user, info, status) =>
           this.handleRequest(err, user, info, context, status)
       );
@@ -112,6 +112,11 @@ function createAuthGuard(type?: string | string[]): Type<IAuthGuard> {
   }
   const guard = mixin(MixinAuthGuard);
   return guard as Type<IAuthGuard>;
+}
+
+function omitAuthModuleOptions(options: IAuthModuleOptions): any {
+  const { defaultStrategy, property, ...authenticateOptions } = options;
+  return authenticateOptions;
 }
 
 const createPassportContext =

--- a/test/common/app.e2e-spec.ts
+++ b/test/common/app.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { spec, request } from 'pactum';
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { OptionsCheckModule } from '../options-check/options-check.module';
 import { AppModule as WithRegisterModule } from '../with-register/app.module';
 import { AppModule as WithoutRegisterModule } from '../without-register/app.module';
 
@@ -48,6 +49,35 @@ describe.each`
         .withHeaders('Authorization', 'Bearer not-a-jwt')
         .expectStatus(401);
     });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});
+
+describe('Passport authenticate options', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const modRef = await Test.createTestingModule({
+      imports: [OptionsCheckModule]
+    }).compile();
+    app = modRef.createNestApplication();
+    await app.listen(0);
+    const url = (await app.getUrl()).replace('[::1]', 'localhost');
+    request.setBaseUrl(url);
+  });
+
+  it('should not pass module-only options to the strategy', async () => {
+    await spec()
+      .get('/options-check')
+      .expectStatus(200)
+      .expectBody({
+        account: { id: 'account-1' },
+        authInfo: { receivedSessionOption: false },
+        user: null
+      });
   });
 
   afterAll(async () => {

--- a/test/options-check/options-check.controller.ts
+++ b/test/options-check/options-check.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '../../lib';
+
+@Controller()
+export class OptionsCheckController {
+  @UseGuards(AuthGuard())
+  @Get('options-check')
+  checkOptions(@Req() req: any) {
+    return {
+      account: req.account,
+      authInfo: req.authInfo,
+      user: req.user ?? null
+    };
+  }
+}

--- a/test/options-check/options-check.module.ts
+++ b/test/options-check/options-check.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { PassportModule } from '../../lib';
+import { OptionsCheckController } from './options-check.controller';
+import { OptionsCheckStrategy } from './options-check.strategy';
+
+@Module({
+  controllers: [OptionsCheckController],
+  imports: [
+    PassportModule.register({
+      defaultStrategy: 'options-check',
+      property: 'account',
+      session: false
+    })
+  ],
+  providers: [OptionsCheckStrategy]
+})
+export class OptionsCheckModule {}

--- a/test/options-check/options-check.strategy.ts
+++ b/test/options-check/options-check.strategy.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import * as passport from 'passport';
+
+const PassportStrategyBase = require('passport-strategy');
+
+@Injectable()
+export class OptionsCheckStrategy extends PassportStrategyBase {
+  name = 'options-check';
+
+  constructor() {
+    super();
+    passport.use(this);
+  }
+
+  authenticate(req: any, options: Record<string, any>) {
+    const leakedOptionKeys = ['defaultStrategy', 'property'].filter(
+      (key) => key in options
+    );
+
+    if (leakedOptionKeys.length > 0) {
+      return this.fail(
+        { message: `Leaked options: ${leakedOptionKeys.join(', ')}` },
+        401
+      );
+    }
+
+    return this.success(
+      { id: 'account-1' },
+      {
+        receivedSessionOption: options.session
+      }
+    );
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`AuthGuard` merges module-level options with per-request authenticate options and passes the whole object to `passport.authenticate()`. This leaks Nest module-only options such as `defaultStrategy` and `property` into Passport strategies even though those options are only meant for Nest's guard behavior.

Issue Number: Fixes #947


## What is the new behavior?

`AuthGuard` now strips module-only options before calling `passport.authenticate()`, while still using the full merged options internally to select the default strategy and assign the authenticated user to the configured request property.

The public `IAuthGuard.getAuthenticateOptions()` type now also reflects that async authenticate options are supported, matching the implementation that already awaits this hook.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Docs were not updated because this is a guard behavior/type fix with regression coverage.

Local validation:

```bash
npm test -- test/common/app.e2e-spec.ts
npm test
npm run build
npm run lint
npx prettier --check lib/auth.guard.ts test/common/app.e2e-spec.ts test/options-check/options-check.controller.ts test/options-check/options-check.module.ts test/options-check/options-check.strategy.ts
git diff --check
```

Note: local validation used Node 24 because the current Vite/Vitest/Oxlint toolchain requires a newer Node runtime than Node 20.18.
